### PR TITLE
Color Wheel and SignaturePadView updates

### DIFF
--- a/DSoft.MAUI.Controls/ColorPicker/ColorWheelView.cs
+++ b/DSoft.MAUI.Controls/ColorPicker/ColorWheelView.cs
@@ -1,12 +1,8 @@
-﻿using DSoft.Maui.Controls.Extensions;
+﻿#nullable enable
+using DSoft.Maui.Controls.Extensions;
 using SkiaSharp.Views.Maui.Controls;
 using SkiaSharp.Views.Maui;
 using SkiaSharp;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using MColor = Microsoft.Maui.Graphics.Colors;
 using DSoft.Maui.Controls.TouchTracking;
 
@@ -32,9 +28,9 @@ namespace DSoft.Maui.Controls.ColorPicker
 				return results;
 			}
 		}
+		
 		#endregion
-
-
+		
 		#region Bindable Properties
 
 		#region ColorsProperty
@@ -68,6 +64,37 @@ namespace DSoft.Maui.Controls.ColorPicker
 
 
 		#endregion
+
+		#region SelectedColor
+
+		public static readonly BindableProperty SelectedColorProperty = BindableProperty.Create(
+			nameof(SelectedColor),
+			typeof(Color),
+			typeof(ColorWheelView),
+			MColor.Transparent,
+			BindingMode.TwoWay,
+			propertyChanged: OnSelectedColorChanged);
+
+		/// <summary>
+		/// Gets or sets the currently selected color. Setting this from a binding will move the indicator to the matching position on the wheel.
+		/// </summary>
+		public Color SelectedColor
+		{
+			get => (Color)GetValue(SelectedColorProperty);
+			set => SetValue(SelectedColorProperty, value);
+		}
+
+		private static void OnSelectedColorChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var view = (ColorWheelView)bindable;
+			if (view._updatingFromTouch) return;
+
+			if (newValue is Color color && color != MColor.Transparent)
+				view.SetTouchLocationFromColor(color);
+		}
+
+		#endregion
+
 		#endregion
 
 		#region Fields
@@ -122,16 +149,24 @@ namespace DSoft.Maui.Controls.ColorPicker
 
 		#region Colors
 
-		//private List<Color> _colors = DefaultColors;
-
 		private SKColor _selectedColor = MColor.Transparent.ToSKColor();
 		#endregion
 
+		#region State
+
+		private bool _updatingFromTouch;
+		private Color? _pendingSelectedColor;
+
+		#endregion
+
 		#region Events
+
 		public event EventHandler<ColorChangedEventArgs> ColorChanged;
+
 		#endregion
 
 		#endregion
+		
 		public ColorWheelView()
 		{
 
@@ -170,6 +205,9 @@ namespace DSoft.Maui.Controls.ColorPicker
 
 			_center = new SKPoint(info.Rect.MidX, info.Rect.MidY);
 			_radius = (Math.Min(info.Width, info.Height) - _shrinkage) / 2;
+
+			if (_pendingSelectedColor is not null)
+				SetTouchLocationFromColor(_pendingSelectedColor);
 
 			_circlePalette.Shader = SKShader.CreateSweepGradient(_center, colorRange, null);
 			canvas.DrawCircle(_center, _radius, _circlePalette);
@@ -214,7 +252,12 @@ namespace DSoft.Maui.Controls.ColorPicker
 						_selectedColor = bmp.GetPixel(0, 0);
 						_touchCircleFill.Color = _selectedColor;
 
-						ColorChanged?.Invoke(this, new ColorChangedEventArgs(_selectedColor.ToMauiColor()));
+						var mauiColor = _selectedColor.ToMauiColor();
+						ColorChanged?.Invoke(this, new ColorChangedEventArgs(mauiColor));
+
+						_updatingFromTouch = true;
+						SelectedColor = mauiColor;
+						_updatingFromTouch = false;
 					}
 				}
 			}
@@ -243,6 +286,40 @@ namespace DSoft.Maui.Controls.ColorPicker
 			{
 				_colorChanged = false;
 			}
+		}
+
+		/// <summary>
+		/// Converts a color back to a touch position on the wheel using hue (angle) and lightness (radius).
+		/// The default color wheel sweeps hues in reverse, so angle = (360 - hue) % 360.
+		/// Lightness maps from 50 (fully saturated edge) to 100 (white center).
+		/// </summary>
+		private void SetTouchLocationFromColor(Color color)
+		{
+			if (_radius == 0 || _center == SKPoint.Empty)
+			{
+				_pendingSelectedColor = color;
+				return;
+			}
+
+			_pendingSelectedColor = null;
+
+			var skColor = color.ToSKColor();
+			skColor.ToHsl(out float h, out _, out float l);
+
+			// The sweep gradient reverses hues (H=360..0 maps to angle 0°..360°)
+			var angleRad = (360f - h) % 360f * (float)(Math.PI / 180.0);
+
+			// L=50 → pure hue at edge, L=100 → white at center
+			var radius = Math.Min(_radius, Math.Max(0f, (100f - l) / 50f * _radius));
+
+			_touchLocation = new SKPoint(
+				_center.X + (float)Math.Cos(angleRad) * radius,
+				_center.Y + (float)Math.Sin(angleRad) * radius);
+
+			_selectedColor = skColor;
+			_touchCircleFill.Color = _selectedColor;
+			_colorChanged = false;
+			_canvasView.InvalidateSurface();
 		}
 
 	}

--- a/DSoft.MAUI.Controls/DSoft.Maui.Controls.csproj
+++ b/DSoft.MAUI.Controls/DSoft.Maui.Controls.csproj
@@ -7,16 +7,9 @@
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
-		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>disable</Nullable>
-		<Authors>newky2k</Authors>
-		<Company>newky2k</Company>
-		<Copyright>newky2k</Copyright>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageTags>maui controls image pinch zoom chart bubble wizard</PackageTags>
+		<PackageTags>maui controls image pinch zoom chart bubble wizard segmented heatmap</PackageTags>
 		<Description>MAUI controls library with Image pan and zoom functionality, wizard view</Description>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">16.0</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">16.0</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">33.0</SupportedOSPlatformVersion>
@@ -24,10 +17,6 @@
         <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 	</PropertyGroup>
-
-	<ItemGroup>
-		<None Include="../README.md" Pack="true" PackagePath="\" />
-	</ItemGroup>
 	
 	<ItemGroup>
 		<PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="3.119.2" />

--- a/DSoft.MAUI.Controls/SignaturePadView.cs
+++ b/DSoft.MAUI.Controls/SignaturePadView.cs
@@ -33,6 +33,15 @@ public class SignaturePadView : ContentView
 
     #endregion
 
+    #region Events
+
+    /// <summary>
+    /// Raised when strokes are added to or cleared from the canvas.
+    /// </summary>
+    public event EventHandler SignatureChanged;
+
+    #endregion
+
     #region Bindable Properties
 
     #region InkColor
@@ -159,10 +168,14 @@ public class SignaturePadView : ContentView
             case SKTouchAction.Cancelled:
             case SKTouchAction.Exited:
                 // Android can fire Exited when touch leaves the view boundary mid-stroke.
-                _activeStrokes.Remove(e.Id);
+                var hadStroke = _activeStrokes.Remove(e.Id);
                 _canvasView.InvalidateSurface();
                 if (_activeStrokes.Count == 0)
+                {
                     SetParentScrollingEnabled(true);
+                    if (hadStroke)
+                        SignatureChanged?.Invoke(this, EventArgs.Empty);
+                }
                 break;
         }
 
@@ -274,6 +287,40 @@ public class SignaturePadView : ContentView
         _strokes.Clear();
         _activeStrokes.Clear();
         _canvasView.InvalidateSurface();
+        SignatureChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Returns the current canvas size in pixels (the native backing-buffer dimensions).
+    /// This is the natural export size — pass it to <see cref="GetImageAsync(int,int,SignatureImageFormat,Color)"/>
+    /// or call the <see cref="GetImageAsync(SignatureImageFormat,Color)"/> overload which uses it automatically.
+    /// Returns <see cref="Size.Zero"/> before the view has been laid out.
+    /// </summary>
+    public Size GetCanvasSize()
+    {
+        var size = _canvasView.CanvasSize;
+        return new Size(size.Width, size.Height);
+    }
+
+    /// <summary>
+    /// Exports the drawn signature as an encoded image at the view's current canvas resolution.
+    /// </summary>
+    /// <param name="format">
+    /// Output format: <see cref="SignatureImageFormat.Png"/> (default) or
+    /// <see cref="SignatureImageFormat.Jpeg"/>.
+    /// </param>
+    /// <param name="backgroundColor">
+    /// Background colour for the exported image. Defaults to <see cref="Colors.White"/>.
+    /// Pass <see cref="Colors.Transparent"/> with <see cref="SignatureImageFormat.Png"/> for a
+    /// transparent background.
+    /// </param>
+    /// <returns>The encoded image as a byte array, or an empty array if nothing has been drawn.</returns>
+    public Task<byte[]> GetImageAsync(
+        SignatureImageFormat format = SignatureImageFormat.Png,
+        Color backgroundColor = null)
+    {
+        var size = _canvasView.CanvasSize;
+        return GetImageAsync((int)size.Width, (int)size.Height, format, backgroundColor);
     }
 
     /// <summary>

--- a/DSoft.Maui.Controls.Core/DSoft.Maui.Controls.Core.csproj
+++ b/DSoft.Maui.Controls.Core/DSoft.Maui.Controls.Core.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <Description>Core models and types for DSoft.Maui.Controls</Description>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,7 @@
 		<RepositoryType>git</RepositoryType>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>Latest</LangVersion>
+		<Nullable>enable</Nullable>
 		<NoWarn>1701;1702;CS8002;CS8653;CS8600;CS1591;CS8603;CS8602;CS8765;CS8618;CS8604;</NoWarn>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,10 @@
 		<Nullable>enable</Nullable>
 		<NoWarn>1701;1702;CS8002;CS8653;CS8600;CS1591;CS8603;CS8602;CS8765;CS8618;CS8604;</NoWarn>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<Authors>newky2k</Authors>
+		<Company>newky2k</Company>
+		<Copyright>newky2k</Copyright>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/MauiSampleApp/ColorPickerPage.xaml
+++ b/MauiSampleApp/ColorPickerPage.xaml
@@ -2,7 +2,9 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:mauic="http://dsoft.maui/schemas/controls"
+             xmlns:local="clr-namespace:MauiSampleApp"
              x:Class="MauiSampleApp.ColorPickerPage"
+             x:DataType="local:ColorPickerPageViewModel"
              Title="Color Picker">
     <ContentPage.ToolbarItems>
         <ToolbarItem Text="Close" Clicked="OnCloseClicked" />
@@ -10,7 +12,10 @@
     <VerticalStackLayout>
         <mauic:ColorPickerView WidthRequest="400" HeightRequest="400" />
         
-        <mauic:ColorWheelView WidthRequest="400" HeightRequest="300" />
+        <mauic:ColorWheelView 
+            SelectedColor="{Binding SelectedColor}"
+            WidthRequest="400" 
+            HeightRequest="300" />
         
     </VerticalStackLayout>
 </ContentPage>

--- a/MauiSampleApp/ColorPickerPage.xaml.cs
+++ b/MauiSampleApp/ColorPickerPage.xaml.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using System.Mvvm;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -8,13 +10,44 @@ namespace MauiSampleApp;
 
 public partial class ColorPickerPage : ContentPage
 {
+    private ColorPickerPageViewModel _viewModel;
+
+    internal ColorPickerPageViewModel ViewModel
+    {
+        get => _viewModel;
+        set { _viewModel = value; BindingContext = _viewModel; }
+    }
+    
     public ColorPickerPage()
     {
         InitializeComponent();
+
+        ViewModel = new();
     }
     
     private async void OnCloseClicked(object? sender, EventArgs e)
     {
         await Navigation.PopModalAsync();
+    }
+}
+
+public class ColorPickerPageViewModel : ViewModel
+{
+
+    private Color _selectedColor;
+
+    public Color SelectedColor
+    {
+        get => _selectedColor;
+        set
+        {
+            _selectedColor = value;
+            NotifyPropertyChanged(nameof(SelectedColor));
+        }
+    }
+    
+    public ColorPickerPageViewModel()
+    {
+        SelectedColor = Colors.Red;
     }
 }

--- a/README.md
+++ b/README.md
@@ -659,6 +659,74 @@ When `GetImageAsync` is called, a new off-screen `SKSurface` is created at the r
 
 ---
 
+# ColorWheelView
+
+`ColorWheelView` is a SkiaSharp-based interactive color wheel. The wheel renders a full HSL hue sweep with an optional white radial gradient overlay at the centre, allowing users to pick any hue at varying saturation levels. A circular indicator follows the touch point and reflects the selected color.
+
+## Basic Usage
+
+```xaml
+xmlns:controls="http://dsoft.maui/schemas/controls"
+
+<controls:ColorWheelView
+    x:Name="ColorWheel"
+    HeightRequest="300"
+    WidthRequest="300"
+    HorizontalOptions="Center"
+    SelectedColor="{Binding PickedColor}"
+    ColorChanged="OnColorChanged" />
+```
+
+## MVVM / Data Binding
+
+`SelectedColor` is a two-way bindable property. Setting it from a view-model moves the indicator to the matching position on the wheel; touching the wheel updates the binding automatically.
+
+```xaml
+<controls:ColorWheelView
+    SelectedColor="{Binding PickedColor, Mode=TwoWay}"
+    HeightRequest="300"
+    WidthRequest="300" />
+```
+
+```csharp
+// ViewModel
+[ObservableProperty]
+private Color _pickedColor = Colors.Red;
+```
+
+When `SelectedColor` is set before the wheel has been laid out (e.g. on page load), the position is calculated and applied as soon as the first paint completes.
+
+## Code-Behind Event
+
+```csharp
+private void OnColorChanged(object sender, ColorChangedEventArgs e)
+{
+    MyPreviewBox.BackgroundColor = e.Color;
+}
+```
+
+## Bindable Properties Reference
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `SelectedColor` | `Color` | `Transparent` | The currently selected color. Two-way bindable — setting this moves the indicator to the corresponding wheel position. |
+| `Colors` | `IEnumerable<Color>` | 8 evenly-spaced HSL hues | The hue gradient colors used to build the sweep. Replace to create a restricted palette wheel. |
+| `ShowWhite` | `bool` | `true` | When `true`, overlays a radial white-to-transparent gradient at the centre, allowing desaturated/pastel colors to be picked. |
+
+## Events
+
+| Event | Args type | Description |
+|---|---|---|
+| `ColorChanged` | `ColorChangedEventArgs` | Raised when the user touches the wheel and the selected color changes. `e.Color` contains the new `Color` value. |
+
+## How It Works
+
+The wheel is drawn on an `SKCanvasView` using two overlaid shaders: a `SKShader.CreateSweepGradient` for the hue ring and a `SKShader.CreateRadialGradient` for the white centre fade. Touch is tracked via `TouchEffect`; when a touch point lands inside the wheel radius, the pixel at that location is sampled directly from the rendered surface to determine the exact color.
+
+When `SelectedColor` is set programmatically the reverse mapping is applied: the color's HSL hue determines the sweep angle (`angle = (360 − H) % 360°`) and its lightness determines the radial distance from the center (`L = 50` → edge, `L = 100` → white center). The indicator circle is repositioned accordingly and the canvas is invalidated.
+
+---
+
 # TabView
 
 `TabView` is a tab container that uses the built-in `SegmentedControl` as its tab bar. Add `TabItem` children in XAML — the tab bar is built automatically from their titles and selecting a segment instantly shows the matching content view.


### PR DESCRIPTION
Updated Color Wheel with ability to bind the selected color and have it correctly locate it in the color wheel

Updated SignaturePadView

 - Added event to capture when the signature has changed
 - Added method to get the current canvas size
 - Added override to GetImageAsync that uses the new canvas size instead of taking the size as a parameter

Updates to some build variables and comments on the Core nuget